### PR TITLE
token contracts - upgradability

### DIFF
--- a/contracts/IkuToken.sol
+++ b/contracts/IkuToken.sol
@@ -2,14 +2,17 @@ pragma solidity ^0.4.21;
 
 import 'openzeppelin-solidity/contracts/token/ERC20/StandardToken.sol';
 import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import "./upgradability/Upgradeable.sol";
 
-contract IkuToken is StandardToken, Ownable {
+contract IkuToken is Upgradeable, StandardToken, Ownable {
     string public constant name = "IkuToken";
     string public constant symbol = "IKU";
     uint8 public constant decimals = 18;
     string public tokenURI;
 
     uint256 public constant INITIAL_SUPPLY = 100000 * (10 ** uint256(decimals));
+
+    bool public isInitialized = false;
 
     constructor() public{
         totalSupply_ = INITIAL_SUPPLY;
@@ -19,5 +22,19 @@ contract IkuToken is StandardToken, Ownable {
 
     function setTokenURI(string _tokenURI) public {
         tokenURI = _tokenURI;
+    }
+
+    /**
+     * @dev initializes the contract by re-setting variables not set by constructor
+     * funtion owing to the proxy pattern architecture
+     * @param sender representing the original
+    **/
+    function initialize(address sender) public payable{
+        require(!isInitialized, "already initialized"); 
+        isInitialized = true;
+        owner = sender;
+        totalSupply_ = INITIAL_SUPPLY;
+        balances[sender] = INITIAL_SUPPLY;
+        emit Transfer(0x0, sender, INITIAL_SUPPLY);
     }
 }

--- a/contracts/IkuToken_v2.sol
+++ b/contracts/IkuToken_v2.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.4.24;
+
+import "./IkuToken.sol";
+
+contract IkuToken_v2 is IkuToken{
+	string public constant name = 'IkuToken_v2';
+	
+	bool public isInitialized = false;
+
+	/**
+     * @dev contract's version getter
+    */
+	function getContractVersion() public pure returns(uint){
+		return 2;
+	}
+
+	/**
+     * @dev proxy initializer function
+     * @param sender representing the original
+    **/
+	function initialize(address sender) public payable{
+		require(!isInitialized, "already initialized");	
+		isInitialized = true;
+		owner = sender;
+		totalSupply_ = INITIAL_SUPPLY;
+        balances[sender] = INITIAL_SUPPLY;
+        emit Transfer(0x0, sender, INITIAL_SUPPLY);
+	}
+}

--- a/contracts/ResearchSpecificToken.sol
+++ b/contracts/ResearchSpecificToken.sol
@@ -1,11 +1,14 @@
 pragma solidity ^0.4.21;
 
 import 'openzeppelin-solidity/contracts/token/ERC20/MintableToken.sol';
+import "./upgradability/Upgradeable.sol";
 
- contract ResearchSpecificToken is MintableToken {
+ contract ResearchSpecificToken is Upgradeable, MintableToken {
     uint8 public  decimals;
     string public  name;
     string public  symbol;
+
+    bool public isInitialized = false;
    
     constructor(
         uint8 _decimalUnits,
@@ -15,5 +18,24 @@ import 'openzeppelin-solidity/contracts/token/ERC20/MintableToken.sol';
         decimals = _decimalUnits;
         name = _tokenName;
         symbol = _tokenSymbol; 
+    }
+
+    /**
+     * @dev proxy initializer function
+     * @param _decimalUnits representing decimals for the ERC20 token
+     * @param _tokenName representing name of the ERC20 token
+     * @param _tokenSymbol representing the symbol for the ERC20 token 
+    **/
+    function initializeRSToken(
+        uint8 _decimalUnits,
+        string _tokenName,
+        string _tokenSymbol
+    ) public {
+        require(!isInitialized, "already initialized");
+        isInitialized = true;
+        owner = msg.sender;
+        decimals = _decimalUnits;
+        name = _tokenName;
+        symbol = _tokenSymbol;
     }
 }

--- a/contracts/ResearchSpecificToken_v2..sol
+++ b/contracts/ResearchSpecificToken_v2..sol
@@ -1,0 +1,40 @@
+pragma solidity ^0.4.24;
+
+import "./ResearchSpecificToken.sol";
+
+contract ResearchSpecificToken_v2 is ResearchSpecificToken{
+
+    bool public isInitialized = false;
+
+	constructor(
+        uint8 _decimalUnits,
+        string _tokenName,
+        string _tokenSymbol
+    ) ResearchSpecificToken(_decimalUnits, _tokenName, _tokenSymbol) public{}
+
+    /**
+	 * @dev proxy initializer function
+	 * @param _decimalUnits representing decimals for the ERC20 token
+	 * @param _tokenName representing name of the ERC20 token
+	 * @param _tokenSymbol representing the symbol for the ERC20 token 
+	**/
+    function initializeRSToken(
+        uint8 _decimalUnits,
+        string _tokenName,
+        string _tokenSymbol
+    ) public {
+    	require(!isInitialized, "already initialized");
+    	isInitialized = true;
+    	owner = msg.sender;
+        decimals = _decimalUnits;
+        name = _tokenName;
+        symbol = _tokenSymbol;
+    }
+
+    /**
+     * @dev contract's version getter
+    */
+    function getContractVersion() public pure returns(uint){
+        return 2;
+    }
+}

--- a/contracts/upgradability/IRegistry.sol
+++ b/contracts/upgradability/IRegistry.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.4.24;
+
+/**
+ * @title IRegistry
+ * @dev This contract represents the interface of a registry contract
+ */
+interface IRegistry {
+  /**
+  * @dev This event will be emitted every time a new proxy is created
+  * @param contractName representing the name of one of the three contracts
+  * @param version representing the version name of the registered implementation
+  * @param proxy representing the address of the proxy created
+  */
+  event ProxyCreated(string contractName, string version, address indexed proxy);
+
+  /**
+  * @dev This event will be emitted every time a new implementation is registered
+  * @param contractName representing the name of one of the three contracts
+  * @param version representing the version name of the registered implementation
+  * @param implementation representing the address of the registered implementation
+  */
+  event VersionAdded(string contractName, string version, address indexed implementation);
+
+  /**
+  * @dev Registers a new version with its implementation address
+  * @param contractName representing the name of one of the three contracts
+  * @param version representing the version name of the new implementation to be registered
+  * @param implementation representing the address of the new implementation to be registered
+  */
+  function addVersion(string contractName, string version, address implementation) external;
+
+  /**
+  * @dev Tells the address of the implementation for a given version
+  * @param contractName representing the name of one of the three contracts
+  * @param version to query the implementation of
+  * @return address of the implementation registered for the given version
+  */
+  function getVersion(string contractName, string version) external view returns (address);
+}

--- a/contracts/upgradability/Proxy.sol
+++ b/contracts/upgradability/Proxy.sol
@@ -1,0 +1,35 @@
+pragma solidity ^0.4.18;
+
+/**
+ * @title Proxy
+ * @dev Gives the possibility to delegate any call to a foreign implementation.
+ */
+contract Proxy {
+
+  /**
+  * @dev Tells the address of the implementation where every call will be delegated.
+  * @return address of the implementation to which it will be delegated
+  */
+  function implementation() public view returns (address);
+
+  /**
+  * @dev Fallback function allowing to perform a delegatecall to the given implementation.
+  * This function will return whatever the implementation call returns
+  */
+  function () payable public {
+    address _impl = implementation();
+    require(_impl != address(0));
+
+    assembly {
+      let ptr := mload(0x40)
+      calldatacopy(ptr, 0, calldatasize)
+      let result := delegatecall(gas, _impl, ptr, calldatasize, 0, 0)
+      let size := returndatasize
+      returndatacopy(ptr, 0, size)
+
+      switch result
+      case 0 { revert(ptr, size) }
+      default { return(ptr, size) }
+    }
+  }
+}

--- a/contracts/upgradability/Registry.sol
+++ b/contracts/upgradability/Registry.sol
@@ -1,0 +1,49 @@
+pragma solidity ^0.4.24;
+
+import './IRegistry.sol';
+import './Upgradeable.sol';
+import './UpgradeabilityProxy.sol';
+
+/**
+ * @title Registry
+ * @dev This contract works as a registry of versions, it holds the implementations for the registered versions.
+ */
+contract Registry is IRegistry {
+  // Mapping of versions to implementations of different functions
+  mapping (string => mapping (string => address)) internal versions;
+
+  /**
+  * @dev Registers a new version with its implementation address
+  * @param contractName representing the name of one of the three contracts
+  * @param version representing the version name of the new implementation to be registered
+  * @param implementation representing the address of the new implementation to be registered
+  */
+  function addVersion(string contractName, string version, address implementation) external {
+    require(versions[contractName][version] == 0x0, 'contract version address already exists');
+    versions[contractName][version] = implementation;
+    emit VersionAdded(contractName, version, implementation);
+  }
+
+  /**
+  * @dev Tells the address of the implementation for a given version
+  * @param contractName representing the name of one of the three contracts
+  * @param version to query the implementation of
+  * @return address of the implementation registered for the given version
+  */
+  function getVersion(string contractName, string version) external view returns (address) {
+    return versions[contractName][version];
+  }
+
+  /**
+  * @dev Creates an upgradeable proxy
+  * @param contractName representing the name of one of the three contracts
+  * @param version representing the first version to be set for the proxy
+  * @return address of the new proxy created
+  */
+  function createProxy(string contractName, string version) public payable returns (UpgradeabilityProxy) {
+    UpgradeabilityProxy proxy = new UpgradeabilityProxy(contractName, version);
+    Upgradeable(proxy).initialize.value(msg.value)(msg.sender);
+    emit ProxyCreated(contractName, version, proxy);
+    return proxy;
+  }
+}

--- a/contracts/upgradability/UpgradeabilityProxy.sol
+++ b/contracts/upgradability/UpgradeabilityProxy.sol
@@ -1,0 +1,29 @@
+pragma solidity ^0.4.24;
+
+import './Proxy.sol';
+import './IRegistry.sol';
+import './UpgradeabilityStorage.sol';
+
+/**
+ * @title UpgradeabilityProxy
+ * @dev This contract represents a proxy where the implementation address to which it will delegate can be upgraded
+ */
+contract UpgradeabilityProxy is Proxy, UpgradeabilityStorage {
+
+  /**
+  * @dev Constructor function
+  */
+  constructor(string _contractName, string _version) public {
+    registry = IRegistry(msg.sender);
+    upgradeTo(_contractName, _version);
+  }
+
+  /**
+  * @dev Upgrades the implementation to the requested version
+  * @param _contractName representing the name of one of the three contracts
+  * @param _version representing the version name of the new implementation to be set
+  */
+  function upgradeTo(string _contractName, string _version) public {
+    _implementation = registry.getVersion(_contractName, _version);
+  }
+}

--- a/contracts/upgradability/UpgradeabilityStorage.sol
+++ b/contracts/upgradability/UpgradeabilityStorage.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.4.24;
+
+import './IRegistry.sol';
+
+/**
+ * @title UpgradeabilityStorage
+ * @dev This contract holds all the necessary state variables to support the upgrade functionality
+ */
+contract UpgradeabilityStorage {
+  // Versions registry
+  IRegistry internal registry;
+
+  // Address of the current implementation
+  address internal _implementation;
+
+  /**
+  * @dev Tells the address of the current implementation
+  * @return address of the current implementation
+  */
+  function implementation() public view returns (address) {
+    return _implementation;
+  }
+}

--- a/contracts/upgradability/Upgradeable.sol
+++ b/contracts/upgradability/Upgradeable.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.4.24;
+
+import './UpgradeabilityStorage.sol';
+
+/**
+ * @title Upgradeable
+ * @dev This contract holds all the minimum required functionality for a behavior to be upgradeable.
+ * This means, required state variables for owned upgradeability purpose and simple initialization validation.
+ */
+contract Upgradeable is UpgradeabilityStorage {
+  /**
+  * @dev Validates the caller is the versions registry.
+  * THIS FUNCTION SHOULD BE OVERRIDDEN CALLING SUPER
+  * @param sender representing the address deploying the initial behavior of the contract
+  */
+  function initialize(address sender) public payable {
+    require(msg.sender == address(registry), 'msg.sender != registry');
+  }
+}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,55 +1,35 @@
-const IkuToken = artifacts.require(`./IkuToken.sol`);
-//const ResearchSpecificToken = artifacts.require(`./ResearchSpecificToken.sol`);
-//const RSTCrowdsale = artifacts.require(`./RSTCrowdsale.sol`);
+const Registry = artifacts.require("Registry");
+const IkuToken = artifacts.require("IkuToken");
 
 module.exports = (deployer) => {
-  deployer.deploy(IkuToken)
-  .then ( t  => {
-  		//console.log("TOKEN DEPLOYED: ", t);
-  		//const token = IkuToken.at(IkuToken.address);
-  		//token.transferOwnership(web3.eth.accounts[0]);
+  var registry;
+  var ikuToken, ikuTokenProxy;
 
-  		/*
-  		 *
-		 * This is helpful for debugging but not used in production
+  // only deploy registry contracts once
+  deployer.deploy(Registry);
 
+  //deploy all version-1 contracts
+  deployer.deploy(IkuToken);
 
-  		const decimal_units = 18;
-		const token_name = 'Research X';
-		const token_symbol = 'RSX';
-
-  		return deployer.deploy(ResearchSpecificToken, decimal_units, token_name, token_symbol).then( token =>{  
-  			
-  			const startTime = web3.eth.getBlock('latest').timestamp  + 60;
-  			//10 minutes later
-		  	const endTime = startTime + (60 * 10);
-
-		  	const rate = new web3.BigNumber(1000);
-		  	const goal = new web3.BigNumber(web3.toWei(300, 'ether'));
-		  	const cap = new web3.BigNumber(web3.toWei(300, 'ether'));
-		  	const wallet = "0x627306090abab3a6e1400e9345bc60c78a8bef57";
-		  	
-
-  			return deployer.deploy(RSTCrowdsale, startTime, endTime, rate, goal, cap, wallet, ResearchSpecificToken.address).then(_ =>{
-  				const token = ResearchSpecificToken.at(ResearchSpecificToken.address);
-  				token.transferOwnership(RSTCrowdsale.address).then( __ =>{
-  					console.log("Deployment complete!");
-  				}).catch( e =>{
-  					console.log("Cant transfer token ownership", e);
-  				});
-
-  				
-
-  			 }).catch( e =>{
-  				console.log("RSTCrowdsale Deployment failed", e);
-  			});
-  	     
-  		 }).catch( e =>{
-  			console.log("ResearchSpecificToken Deployment failed", e);
-  		});
-  		*/  		
-  }).catch( e =>{
-  		console.log("IkuToken Deployment failed", e);
+  // step 1 : register deployed version-1 contracts with the registry contract
+  // step 2 : creating proxies
+  // step 3 : fetch proxy addresses
+  deployer.then(() => {
+    return Registry.deployed();
+  }).then(instance => {
+    registry = instance;
+    return IkuToken.deployed();
+  }).then(instance => {
+    ikuToken = instance;
+    return registry.addVersion('IkuToken', '1.0', ikuToken.address);
+  }).then(tx => {
+    return registry.createProxy('IkuToken', '1.0');
+  }).then(tx => {
+    ikuTokenProxy = tx.logs[0].args.proxy;
+    console.log('IkuToken proxy: ', ikuTokenProxy);
   });
-  
+
+  // step 4 : call any uncalled initializers
+  // Note : there's no need to call initialize on Ikutoken because it's 
+  //        automatically called by registry on proxy creation the first time.
 }

--- a/migrations/3_update_contracts.js
+++ b/migrations/3_update_contracts.js
@@ -1,0 +1,56 @@
+const Registry = artifacts.require("Registry");
+const IkuToken_v2 = artifacts.require("IkuToken_v2");
+const Proxy = artifacts.require('UpgradeabilityProxy');
+
+//helper function to fetch proxy addresses
+function getLogs(filter) {
+  return new Promise((resolve, reject) => {
+    filter.get((error, events) => {
+      if (error) return reject(error);
+      resolve(events);
+    });
+  });
+}
+
+module.exports = (deployer, network, accounts) => {
+	var registry;
+	var ikuToken_v2, ikuTokenProxy;
+
+	//deploy all version-2 contracts
+	deployer.deploy(IkuToken_v2);
+
+	// step 1 : register deployed version-2 contracts with the registry contract
+	deployer.then(() => {
+		return Registry.deployed();
+	}).then(instance => {
+		registry = instance;
+		return IkuToken_v2.deployed();
+	}).then(instance => {
+		ikuToken_v2 = instance;
+		return registry.addVersion('IkuToken', '2.0', ikuToken_v2.address);
+	}).then(tx => {
+		console.log("new version of IkuToken added to the registry.")
+	})
+
+	// step 2 : fetch created proxies
+	// step 3 : call upgradeTo function on proxies
+	deployer.then(()=>{
+		return registry.ProxyCreated({},{ fromBlock: 0, toBlock: 'latest' });
+	}).then(filter => {
+		return getLogs(filter);
+	}).then(events => {
+		ikuTokenProxy = events[0].args.proxy;
+		console.log("Upgrading ikuTokenProxy to reflect contract version 2 ...");
+		return Proxy.at(ikuTokenProxy).upgradeTo('IkuToken', '2.0');
+	}).then(tx => {
+		console.log("Update Completed!");
+	});
+
+	//step 4 : call respective contract initializers
+	deployer.then(()=>{
+		console.log('initializing IkuToken_v2 ...');
+		return IkuToken_v2.at(ikuTokenProxy).initialize(accounts[1], { from: accounts[1] });;
+	}).then(tx => {
+		console.log('IkuToken_v2 initialized!');
+	});
+}

--- a/test/Upgradability_Version1.js
+++ b/test/Upgradability_Version1.js
@@ -1,0 +1,262 @@
+import ether from './helpers/ether';
+import { increaseTimeTo, duration } from './helpers/increaseTime';
+import getLogs from './helpers/getLogs';
+import latestTime from './helpers/latestTime';
+import EVMRevert from './helpers/EVMRevert';
+
+const { BigNumber } = web3;
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
+
+const IkuToken = artifacts.require('IkuToken');
+const ResearchSpecificToken = artifacts.require('ResearchSpecificToken');
+const RSTCrowdsale = artifacts.require('RSTCrowdsale');
+
+const Registry = artifacts.require('Registry');
+const Proxy = artifacts.require('UpgradeabilityProxy');
+
+contract('Upgradability for version-1 contracts', accounts => {
+  const creator = accounts[0];
+
+  const RATE = new BigNumber(1000);
+  const GOAL = ether(300);
+  const CAP = ether(300);
+
+  let ikuToken_v1;
+  let researchSpecificToken_v1;
+
+  let registry;
+
+  let ikuTokenProxy;
+  let researchSpecificTokenProxy;
+
+  let tx;
+
+  it('should be able to register initial contract versions & create proxies', async () => {
+    ikuToken_v1 = await IkuToken.new();
+
+    researchSpecificToken_v1 = await ResearchSpecificToken.new(
+      18,
+      'ResearchSpecificToken',
+      'RST'
+    );
+
+    registry = await Registry.new();
+
+    await registry.addVersion('IkuToken', '1.0', ikuToken_v1.address);
+
+    await registry.addVersion(
+      'ResearchSpecificToken',
+      '1.0',
+      researchSpecificToken_v1.address
+    );
+
+    // creating proxies & upgrading to initial version
+    tx = await registry.createProxy('IkuToken', '1.0');
+    ikuTokenProxy = tx.logs[0].args.proxy;
+
+    tx = await registry.createProxy('ResearchSpecificToken', '1.0');
+    researchSpecificTokenProxy = tx.logs[0].args.proxy;
+
+    ikuTokenProxy.should.exist;
+    researchSpecificTokenProxy.should.exist;
+  });
+
+  it('should emit ProxyCreated events for each of the two contracts', async () => {
+    const proxyFilter = await registry.ProxyCreated(
+      {},
+      { fromBlock: 0, toBlock: 'latest' }
+    );
+    const events = await getLogs(proxyFilter);
+    assert.equal(ikuTokenProxy, events[0].args.proxy);
+    assert.equal(researchSpecificTokenProxy, events[1].args.proxy);
+  });
+
+  describe('deployed proxy contracts should pass all individual tests(version-1)', () => {
+    describe('IkuToken_v1 proxy', () => {
+      let token;
+
+      before(async () => {
+        token = IkuToken.at(ikuTokenProxy);
+      });
+
+      it('should be initialized with owner set correctly', async () => {
+        const isInitialized = await token.isInitialized();
+        assert.equal(isInitialized, true);
+        assert.equal(creator, await token.owner());
+      });
+
+      it('has a name (IkuToken_v1)', async () => {
+        const name = await token.name();
+        assert.equal(name, 'IkuToken');
+      });
+
+      it('has a symbol (IKU)', async () => {
+        const symbol = await token.symbol();
+        assert.equal(symbol, 'IKU');
+      });
+
+      it('has 18 decimals', async () => {
+        const decimals = await token.decimals();
+        assert(decimals.eq(18));
+      });
+
+      it('has an initial supply of 100000', async () => {
+        const totalSupply = await token.totalSupply();
+        assert(totalSupply.equals(100000 * 10 ** 18));
+      });
+
+      it('can have a tokenURI', async () => {
+        const URI =
+          'https://ipfs.io/ipfs/QmQBEwQYc3hGprxvCcW2owr4X1uwQqCpusTJkQuoTDhL5r';
+        await token.setTokenURI(URI, { from: creator });
+        const tokenURI = await token.tokenURI();
+        assert.equal(tokenURI, URI);
+      });
+
+      it('assigns the initial total supply to the creator', async () => {
+        const totalSupply = await token.totalSupply();
+        const creatorBalance = await token.balanceOf(creator);
+        assert(creatorBalance.eq(totalSupply));
+      });
+    });
+
+    describe('ResearchSpecificToken_v1 proxy', () => {
+      let token;
+
+      before(async () => {
+        token = ResearchSpecificToken.at(researchSpecificTokenProxy);
+        const isInitialized = await token.isInitialized();
+        // make sure that contract has not been initialized yet
+        assert.equal(isInitialized, false);
+        await token.initializeRSToken(18, 'ResearchSpecificToken', 'RST');
+      });
+
+      it('should be initialized with owner set correctly', async () => {
+        const isInitialized = await token.isInitialized();
+        assert.equal(isInitialized, true);
+        assert.equal(creator, await token.owner());
+      });
+
+      it('has a name', async () => {
+        const name = await token.name();
+        assert.equal(name, 'ResearchSpecificToken');
+      });
+
+      it('has a symbol', async () => {
+        const symbol = await token.symbol();
+        assert.equal(symbol, 'RST');
+      });
+
+      it('has 18 decimals', async () => {
+        const decimals = await token.decimals();
+        assert(decimals.eq(18));
+      });
+    });
+
+    describe('RSTCrowdsale contract with deployed ResearchSpecificToken proxy(version-1)', () => {
+      let token;
+      let crowdsale;
+
+      const owner = accounts[0];
+      const wallet = accounts[8];
+      const investor = accounts[7];
+      const openingTime = latestTime() + duration.minutes(1);
+      const closingTime = openingTime + duration.weeks(1);
+      const afterClosingTime = closingTime + duration.seconds(1);
+
+      before(async () => {
+        token = ResearchSpecificToken.at(researchSpecificTokenProxy);
+        const isInitialized = await token.isInitialized();
+        assert.equal(isInitialized, true);
+        assert.equal(creator, await token.owner());
+
+        crowdsale = await RSTCrowdsale.new(
+          openingTime,
+          openingTime + duration.weeks(1),
+          RATE,
+          wallet,
+          CAP,
+          researchSpecificTokenProxy,
+          GOAL
+        );
+
+        await token.transferOwnership(crowdsale.address);
+      });
+
+      it('should create crowdsale with correct parameters', async () => {
+        crowdsale.should.exist;
+        token.should.exist;
+
+        const openingTime = await crowdsale.openingTime();
+        const closingTime = await crowdsale.closingTime();
+        const rate = await crowdsale.rate();
+        const walletAddress = await crowdsale.wallet();
+        const goal = await crowdsale.goal();
+        const cap = await crowdsale.cap();
+        const tokenName = await token.name();
+        const tokenSymbol = await token.symbol();
+        const decimalUnits = await token.decimals();
+
+        openingTime.should.be.bignumber.equal(openingTime);
+        closingTime.should.be.bignumber.equal(closingTime);
+        rate.should.be.bignumber.equal(RATE);
+        walletAddress.should.be.equal(wallet);
+        goal.should.be.bignumber.equal(GOAL);
+        cap.should.be.bignumber.equal(CAP);
+        tokenName.should.be.equal('ResearchSpecificToken');
+        tokenSymbol.should.be.equal('RST');
+        decimalUnits.should.be.bignumber.equal(18);
+      });
+
+      it('should not accept payments before start', async () => {
+        await crowdsale.send(ether(1)).should.be.rejectedWith(EVMRevert);
+        await crowdsale
+          .buyTokens(investor, { from: investor, value: ether(1) })
+          .should.be.rejectedWith(EVMRevert);
+      });
+
+      it('should accept payments during the sale', async () => {
+        const investmentAmount = CAP;
+        const expectedTokenAmount = RATE.mul(investmentAmount);
+
+        await increaseTimeTo(openingTime);
+        await crowdsale.buyTokens(investor, {
+          value: investmentAmount,
+          from: investor,
+        }).should.be.fulfilled;
+
+        (await token.balanceOf(investor)).should.be.bignumber.equal(
+          expectedTokenAmount
+        );
+        (await token.totalSupply()).should.be.bignumber.equal(
+          expectedTokenAmount
+        );
+
+        // should reject any payment above cap
+        await crowdsale.send(1).should.be.rejectedWith(EVMRevert);
+      });
+
+      it('should reject payments after end', async () => {
+        await increaseTimeTo(afterClosingTime);
+        await crowdsale.send(ether(1)).should.be.rejectedWith(EVMRevert);
+        await crowdsale
+          .buyTokens(investor, { value: ether(1), from: investor })
+          .should.be.rejectedWith(EVMRevert);
+      });
+
+      it('should allow finalization and transfer funds to wallet if the goal is reached', async () => {
+        const beforeFinalization = web3.eth.getBalance(wallet);
+        await crowdsale.finalize({ from: owner });
+        const afterFinalization = web3.eth.getBalance(wallet);
+
+        afterFinalization
+          .minus(beforeFinalization)
+          .should.be.bignumber.equal(GOAL);
+      });
+    });
+  });
+});

--- a/test/Upgradability_Version2.js
+++ b/test/Upgradability_Version2.js
@@ -1,0 +1,309 @@
+import ether from './helpers/ether';
+import getLogs from './helpers/getLogs';
+import { increaseTimeTo, duration } from './helpers/increaseTime';
+import latestTime from './helpers/latestTime';
+import EVMRevert from './helpers/EVMRevert';
+
+const { BigNumber } = web3;
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should();
+
+const IkuToken = artifacts.require('IkuToken');
+const ResearchSpecificToken = artifacts.require('ResearchSpecificToken');
+
+const IkuToken_v2 = artifacts.require('IkuToken_v2');
+const ResearchSpecificToken_v2 = artifacts.require('ResearchSpecificToken_v2');
+
+const RSTCrowdsale = artifacts.require('RSTCrowdsale');
+
+const Registry = artifacts.require('Registry');
+const Proxy = artifacts.require('UpgradeabilityProxy');
+
+contract('Upgradability for version-2 contracts', accounts => {
+  const creator = accounts[0];
+
+  const RATE = new BigNumber(1000);
+  const GOAL = ether(300);
+  const CAP = ether(300);
+
+  let ikuToken_v1;
+  let ikuToken_v2;
+  let researchSpecificToken_v1;
+  let researchSpecificToken_v2;
+
+  let registry;
+
+  let ikuTokenProxy;
+  let researchSpecificTokenProxy;
+
+  let tx;
+
+  it('should be able to register initial contract versions & create proxies', async () => {
+    ikuToken_v1 = await IkuToken.new();
+
+    researchSpecificToken_v1 = await ResearchSpecificToken.new(
+      18,
+      'ResearchSpecificToken',
+      'RST1'
+    );
+
+    registry = await Registry.new();
+
+    await registry.addVersion('IkuToken', '1.0', ikuToken_v1.address);
+
+    await registry.addVersion(
+      'ResearchSpecificToken',
+      '1.0',
+      researchSpecificToken_v1.address
+    );
+
+    // creating proxies & upgrading to initial version
+    tx = await registry.createProxy('IkuToken', '1.0');
+    ikuTokenProxy = tx.logs[0].args.proxy;
+    tx = await registry.createProxy('ResearchSpecificToken', '1.0');
+    researchSpecificTokenProxy = tx.logs[0].args.proxy;
+
+    assert.equal(await IkuToken.at(ikuTokenProxy).name(), 'IkuToken');
+    // the following resolves to true beacuse contract hasn't been initialized yet
+    assert.equal(
+      await ResearchSpecificToken.at(researchSpecificTokenProxy).name(),
+      ''
+    );
+  });
+
+  it('should be able to update contracts using created proxies', async () => {
+    ikuToken_v2 = await IkuToken_v2.new({ from: accounts[2] });
+
+    researchSpecificToken_v2 = await ResearchSpecificToken_v2.new(
+      18,
+      'ResearchSpecificToken_v2',
+      'RST2'
+    );
+
+    await registry.addVersion('IkuToken', '2.0', ikuToken_v2.address);
+    await registry.addVersion(
+      'ResearchSpecificToken',
+      '2.0',
+      researchSpecificToken_v2.address
+    );
+
+    await Proxy.at(ikuTokenProxy).upgradeTo('IkuToken', '2.0');
+    await Proxy.at(researchSpecificTokenProxy).upgradeTo(
+      'ResearchSpecificToken',
+      '2.0'
+    );
+
+    assert.equal(await IkuToken_v2.at(ikuTokenProxy).name(), 'IkuToken_v2');
+    assert.equal(await IkuToken_v2.at(ikuTokenProxy).getContractVersion(), 2);
+    assert.equal(
+      await ResearchSpecificToken_v2.at(
+        researchSpecificTokenProxy
+      ).getContractVersion(),
+      2
+    );
+  });
+
+  it('should emit ProxyCreated events for each of the two contracts', async () => {
+    const proxyFilter = await registry.ProxyCreated(
+      {},
+      { fromBlock: 0, toBlock: 'latest' }
+    );
+    const events = await getLogs(proxyFilter);
+    assert.equal(ikuTokenProxy, events[0].args.proxy);
+    assert.equal(researchSpecificTokenProxy, events[1].args.proxy);
+  });
+
+  describe('deployed proxy contracts should pass all individual tests(version-2)', () => {
+    describe('IkuToken_v2 proxy', () => {
+      let token;
+
+      before(async () => {
+        token = IkuToken_v2.at(ikuTokenProxy);
+        const isInitialized = await token.isInitialized();
+        // make sure that contract has not been initialized yet
+        assert.equal(isInitialized, false);
+        // initialize the upgraded contract
+        await token.initialize(accounts[2], { from: accounts[2] });
+      });
+
+      it('should be initialized with owner set correctly', async () => {
+        const isInitialized = await token.isInitialized();
+        assert.equal(isInitialized, true);
+        assert.equal(accounts[2], await token.owner());
+      });
+
+      it('has a name (IkuToken_v2)', async () => {
+        const name = await token.name();
+        assert.equal(name, 'IkuToken_v2');
+      });
+
+      it('has a symbol (IKU)', async () => {
+        const symbol = await token.symbol();
+        assert.equal(symbol, 'IKU');
+      });
+
+      it('has 18 decimals', async () => {
+        const decimals = await token.decimals();
+        assert(decimals.eq(18));
+      });
+
+      it('has an initial supply of 100000', async () => {
+        const totalSupply = await token.totalSupply();
+        assert(totalSupply.equals(100000 * 10 ** 18));
+      });
+
+      it('can have a tokenURI', async () => {
+        const URI =
+          'https://ipfs.io/ipfs/QmQBEwQYc3hGprxvCcW2owr4X1uwQqCpusTJkQuoTDhL5r';
+        await token.setTokenURI(URI, { from: creator });
+        const tokenURI = await token.tokenURI();
+        assert.equal(tokenURI, URI);
+      });
+
+      it('assigns the initial total supply to the creator', async () => {
+        const totalSupply = await token.totalSupply();
+        const creatorBalance = await token.balanceOf(creator);
+
+        assert(creatorBalance.eq(totalSupply));
+      });
+    });
+
+    describe('ResearchSpecificToken_v2 proxy', () => {
+      let token;
+
+      before(async () => {
+        token = ResearchSpecificToken_v2.at(researchSpecificTokenProxy);
+        const isInitialized = await token.isInitialized();
+        // make sure that contract has not been initialized yet
+        assert.equal(isInitialized, false);
+        await token.initializeRSToken(18, 'ResearchSpecificToken', 'RST1');
+      });
+
+      it('should be initialized with owner set correctly', async () => {
+        const isInitialized = await token.isInitialized();
+        assert.equal(isInitialized, true);
+        assert.equal(creator, await token.owner());
+      });
+
+      it('has a name', async () => {
+        const name = await token.name();
+        assert.equal(name, 'ResearchSpecificToken');
+      });
+
+      it('has a symbol', async () => {
+        const symbol = await token.symbol();
+        assert.equal(symbol, 'RST1');
+      });
+
+      it('has 18 decimals', async () => {
+        const decimals = await token.decimals();
+        assert(decimals.eq(18));
+      });
+    });
+
+    describe('RSTCrowdsale contract with deployed ResearchSpecificToken proxy', () => {
+      let token;
+      let crowdsale;
+
+      const owner = accounts[0];
+      const wallet = accounts[8];
+      const investor = accounts[7];
+      const openingTime = latestTime() + duration.minutes(1);
+      const closingTime = openingTime + duration.weeks(1);
+      const afterClosingTime = closingTime + duration.seconds(1);
+
+      before(async () => {
+        token = ResearchSpecificToken_v2.at(researchSpecificTokenProxy);
+        const isInitialized = await token.isInitialized();
+        assert.equal(isInitialized, true);
+        assert.equal(creator, await token.owner());
+
+        crowdsale = await RSTCrowdsale.new(
+          openingTime,
+          openingTime + duration.weeks(1),
+          RATE,
+          wallet,
+          CAP,
+          researchSpecificTokenProxy,
+          GOAL
+        );
+
+        await token.transferOwnership(crowdsale.address);
+      });
+
+      it('should create crowdsale with correct parameters', async () => {
+        crowdsale.should.exist;
+        token.should.exist;
+
+        const openingTime = await crowdsale.openingTime();
+        const closingTime = await crowdsale.closingTime();
+        const rate = await crowdsale.rate();
+        const walletAddress = await crowdsale.wallet();
+        const goal = await crowdsale.goal();
+        const cap = await crowdsale.cap();
+        const tokenName = await token.name();
+        const tokenSymbol = await token.symbol();
+        const decimalUnits = await token.decimals();
+
+        openingTime.should.be.bignumber.equal(openingTime);
+        closingTime.should.be.bignumber.equal(closingTime);
+        rate.should.be.bignumber.equal(RATE);
+        walletAddress.should.be.equal(wallet);
+        goal.should.be.bignumber.equal(GOAL);
+        cap.should.be.bignumber.equal(CAP);
+        tokenName.should.be.equal('ResearchSpecificToken');
+        tokenSymbol.should.be.equal('RST1');
+        decimalUnits.should.be.bignumber.equal(18);
+      });
+
+      it('should not accept payments before start', async () => {
+        await crowdsale.send(ether(1)).should.be.rejectedWith(EVMRevert);
+        await crowdsale
+          .buyTokens(investor, { from: investor, value: ether(1) })
+          .should.be.rejectedWith(EVMRevert);
+      });
+
+      it('should accept payments during the sale', async () => {
+        const investmentAmount = CAP;
+        const expectedTokenAmount = RATE.mul(investmentAmount);
+
+        await increaseTimeTo(openingTime);
+        await crowdsale.buyTokens(investor, {
+          value: investmentAmount,
+          from: investor,
+        }).should.be.fulfilled;
+
+        (await token.balanceOf(investor)).should.be.bignumber.equal(
+          expectedTokenAmount
+        );
+        (await token.totalSupply()).should.be.bignumber.equal(
+          expectedTokenAmount
+        );
+
+        // should reject any payment above cap
+        await crowdsale.send(1).should.be.rejectedWith(EVMRevert);
+      });
+
+      it('should reject payments after end', async () => {
+        await increaseTimeTo(afterClosingTime);
+        await crowdsale.send(ether(1)).should.be.rejectedWith(EVMRevert);
+        await crowdsale
+          .buyTokens(investor, { value: ether(1), from: investor })
+          .should.be.rejectedWith(EVMRevert);
+      });
+
+      it('should allow finalization and transfer funds to wallet if the goal is reached', async () => {
+        const beforeFinalization = web3.eth.getBalance(wallet);
+        await crowdsale.finalize({ from: owner });
+        const afterFinalization = web3.eth.getBalance(wallet);
+
+        afterFinalization
+          .minus(beforeFinalization)
+          .should.be.bignumber.equal(GOAL);
+      });
+    });
+  });
+});

--- a/test/helpers/getLogs.js
+++ b/test/helpers/getLogs.js
@@ -1,0 +1,8 @@
+export default function getLogs(filter) {
+  return new Promise((resolve, reject) => {
+    filter.get((error, events) => {
+      if (error) return reject(error);
+      resolve(events);
+    });
+  });
+}


### PR DESCRIPTION
I had trouble reverting all the changes made by linter in the last PR, so I decided it would be better to start fresh. 

I've limited migration files to only IkuToken.js + modified `jobs/deploy_crowdsale` . The only difference is that now it deploys the `ResearchSpecificToken` via the Proxy-pattern design i.e. via the registry contract and stores the Proxy address inside the DB instead of the actual address.

**No changes have been made the `RSTCrowdsale` contract, due to the reasons mentioned in my earlier comment**

I've also updated the tests to include the latest commits.

ref #102 #109 